### PR TITLE
Hide crafting grid in player inventory

### DIFF
--- a/mods/main/init.lua
+++ b/mods/main/init.lua
@@ -129,7 +129,15 @@ core.register_on_joinplayer(function(player)
 	player:set_pos({x=5, y=-9.6, z=8})
 	player:get_inventory():set_list("main", {})
 
+	player:set_inventory_formspec([[
+    		size[8,4]
+    		list[current_player;main;0,0;8,1;]
+    		list[current_player;main;0,1.25;8,3;8]
+    		listring[current_player;main]
+	]])
+
 	local player_name = player:get_player_name()
+	
 	player_data[player_name] = {
 		size = player:get_properties().visual_size,
 		skin = player:get_properties().textures,


### PR DESCRIPTION
does what the title says

before:
<img width="1920" height="1101" alt="before" src="https://github.com/user-attachments/assets/7647a9f8-3928-48af-b514-be6c0d5d362e" />

after:
<img width="1920" height="1101" alt="after" src="https://github.com/user-attachments/assets/09a8e30e-7970-4286-ac26-bfcccc7c673d" />

